### PR TITLE
1.17 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/openjdk:11-jdk
+      - image: cimg/openjdk:16.0.0
 
     working_directory: ~/repo
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -11,10 +11,10 @@ jobs:
       - name: Validation
         uses: gradle/wrapper-validation-action@v1
 
-      - name: JDK 11
+      - name: JDK 16
         uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: '16'
       
       - name: cache
         uses: actions/cache@v2

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ plugins {
 	id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_16
+targetCompatibility = JavaVersion.VERSION_16
 
 archivesBaseName = project.archives_base_name
 version = project.mod_version

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.7-SNAPSHOT'
+	id 'fabric-loom' version '0.8-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.6-SNAPSHOT'
+	id 'fabric-loom' version '0.7-SNAPSHOT'
 	id 'maven-publish'
 }
 
@@ -32,6 +32,7 @@ dependencies {
 }
 
 processResources {
+	duplicatesStrategy DuplicatesStrategy.INCLUDE
 	inputs.property "version", project.version
 
 	from(sourceSets.main.resources.srcDirs) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,12 +2,12 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.16.5
-yarn_mappings=1.16.5+build.5
+minecraft_version=1.17
+yarn_mappings=1.17+build.1
 loader_version=0.11.3
 # Mod Properties
 mod_version=1.4.7
 maven_group=one.oktw
 archives_base_name=FabricProxy
 # Dependencies
-fabric_version=0.32.0+1.16
+fabric_version=0.34.9+1.17

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/one/oktw/mixin/bungee/HandshakeC2SPacketMixin.java
+++ b/src/main/java/one/oktw/mixin/bungee/HandshakeC2SPacketMixin.java
@@ -8,7 +8,7 @@ import org.spongepowered.asm.mixin.injection.ModifyConstant;
 
 @Mixin(HandshakeC2SPacket.class)
 public abstract class HandshakeC2SPacketMixin {
-    @ModifyConstant(method = "read", constant = @Constant(intValue = 255))
+    @ModifyConstant(method = "<init>(Lnet/minecraft/network/PacketByteBuf;)V", constant = @Constant(intValue = 255))
     private int readStringSize(int i) {
         if (FabricProxy.config.getBungeeCord()) {
             return Short.MAX_VALUE;

--- a/src/main/java/one/oktw/mixin/velocity/ServerLoginNetworkHandlerMixin.java
+++ b/src/main/java/one/oktw/mixin/velocity/ServerLoginNetworkHandlerMixin.java
@@ -1,7 +1,6 @@
 package one.oktw.mixin.velocity;
 
 import com.mojang.authlib.GameProfile;
-import net.fabricmc.fabric.mixin.networking.accessor.LoginQueryRequestS2CPacketAccessor;
 import net.fabricmc.fabric.mixin.networking.accessor.LoginQueryResponseC2SPacketAccessor;
 import net.minecraft.network.ClientConnection;
 import net.minecraft.network.PacketByteBuf;
@@ -61,11 +60,11 @@ public abstract class ServerLoginNetworkHandlerMixin {
                 loginPacket = loginHelloC2SPacket;
             }
             this.velocityLoginQueryId = java.util.concurrent.ThreadLocalRandom.current().nextInt();
-            LoginQueryRequestS2CPacket packet = new LoginQueryRequestS2CPacket();
-            ((LoginQueryRequestS2CPacketAccessor) packet).setQueryId(velocityLoginQueryId);
-            ((LoginQueryRequestS2CPacketAccessor) packet).setChannel(VelocityLib.PLAYER_INFO_CHANNEL);
-            ((LoginQueryRequestS2CPacketAccessor) packet).setPayload(new PacketByteBuf(EMPTY_BUFFER));
-
+            LoginQueryRequestS2CPacket packet = new LoginQueryRequestS2CPacket(
+                    velocityLoginQueryId,
+                    VelocityLib.PLAYER_INFO_CHANNEL,
+                    new PacketByteBuf(EMPTY_BUFFER)
+            );
             connection.send(packet);
             ci.cancel();
         }

--- a/src/main/resources/bungee.mixins.json
+++ b/src/main/resources/bungee.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "one.oktw.mixin.bungee",
-  "compatibilityLevel": "JAVA_8",
+  "compatibilityLevel": "JAVA_16",
   "plugin": "one.oktw.FabricProxy",
   "mixins": [
     "ClientConnectionMixin",

--- a/src/main/resources/common.mixins.json
+++ b/src/main/resources/common.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "one.oktw.mixin",
-  "compatibilityLevel": "JAVA_8",
+  "compatibilityLevel": "JAVA_16",
   "mixins": [
     "ClientConnectionAccessor",
     "ServerConfigHandlerMixin",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -22,7 +22,7 @@
     "velocity.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.4.0",
+    "fabricloader": ">=0.11.3",
     "fabric": "*"
   },
   "suggests": {}

--- a/src/main/resources/velocity.mixins.json
+++ b/src/main/resources/velocity.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "one.oktw.mixin.velocity",
-  "compatibilityLevel": "JAVA_8",
+  "compatibilityLevel": "JAVA_16",
   "plugin": "one.oktw.FabricProxy",
   "mixins": [
     "ServerLoginNetworkHandlerMixin"


### PR DESCRIPTION
Updated Fabric and Gradle to support Java 16 and Minecraft 1.17

Have been using this fork privately on BungeeCord since 1.17 prereleases.
No major issues encountered.

Probably need more tests.