### PR TITLE
Update to 1.18. Fix incompatibility with other mods.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: cimg/openjdk:16.0.0
+      - image: cimg/openjdk:17.0.0
 
     working_directory: ~/repo
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -11,10 +11,10 @@ jobs:
       - name: Validation
         uses: gradle/wrapper-validation-action@v1
 
-      - name: JDK 16
+      - name: JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: '16'
+          java-version: '17'
       
       - name: cache
         uses: actions/cache@v2

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 plugins {
-	id 'fabric-loom' version '0.8-SNAPSHOT'
+	id 'fabric-loom' version '0.10-SNAPSHOT'
 	id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_16
-targetCompatibility = JavaVersion.VERSION_16
+sourceCompatibility = JavaVersion.VERSION_17
+targetCompatibility = JavaVersion.VERSION_17
 
 archivesBaseName = project.archives_base_name
 version = project.mod_version
@@ -24,11 +24,12 @@ dependencies {
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}"
 
 	modApi "net.fabricmc:fabric-loader:${project.loader_version}"
-	modApi "com.github.shedaniel:AutoConfig:1.16-SNAPSHOT"
+	
+	modImplementation "com.moandjiezana.toml:toml4j:0.7.2"
+	include "com.moandjiezana.toml:toml4j:0.7.2"
 
 	// API
 	modApi "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
-	include "com.github.shedaniel:AutoConfig:1.16-SNAPSHOT"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,12 +2,12 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.17.1
-yarn_mappings=1.17.1+build.1:v2
-loader_version=0.11.6
+minecraft_version=1.18
+yarn_mappings=1.18+build.1
+loader_version=0.12.6
 # Mod Properties
 mod_version=1.4.9
 maven_group=one.oktw
 archives_base_name=FabricProxy
 # Dependencies
-fabric_version=0.36.1+1.17
+fabric_version=0.43.1+1.18

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/one/oktw/FabricProxy.java
+++ b/src/main/java/one/oktw/FabricProxy.java
@@ -1,13 +1,17 @@
 package one.oktw;
 
-import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
-import me.sargunvohra.mcmods.autoconfig1u.serializer.Toml4jConfigSerializer;
+import com.moandjiezana.toml.Toml;
+import com.moandjiezana.toml.TomlWriter;
+import net.fabricmc.loader.api.FabricLoader;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.objectweb.asm.tree.ClassNode;
 import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
 import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Set;
 
@@ -18,8 +22,17 @@ public class FabricProxy implements IMixinConfigPlugin {
     @Override
     public void onLoad(String mixinPackage) {
         if (config == null) {
-            AutoConfig.register(ModConfig.class, Toml4jConfigSerializer::new);
-            config = AutoConfig.getConfigHolder(ModConfig.class).getConfig();
+            var configFile = FabricLoader.getInstance().getConfigDir().resolve("FabricProxy.toml");
+            if (!Files.exists(configFile)) {
+                config = new ModConfig();
+                try {
+                    new TomlWriter().write(config, configFile.toFile());
+                } catch (IOException e) {
+                    LogManager.getLogger().error("Init config failed.", e);
+                }
+            } else {
+                config = new Toml().read(FabricLoader.getInstance().getConfigDir().resolve("FabricProxy.toml").toFile()).to(ModConfig.class);
+            }
         }
     }
 

--- a/src/main/java/one/oktw/ModConfig.java
+++ b/src/main/java/one/oktw/ModConfig.java
@@ -1,17 +1,11 @@
 package one.oktw;
 
-import me.sargunvohra.mcmods.autoconfig1u.ConfigData;
-import me.sargunvohra.mcmods.autoconfig1u.annotation.Config;
-import me.sargunvohra.mcmods.autoconfig1u.shadowed.blue.endless.jankson.Comment;
-
 @SuppressWarnings({"FieldCanBeLocal", "FieldMayBeFinal"})
-@Config(name = "FabricProxy")
-public class ModConfig implements ConfigData {
+public class ModConfig {
     private Boolean BungeeCord = false;
     private Boolean Velocity = false;
     private Boolean allowBypassProxy = false;
 
-    @Comment("Velocity proxy secret")
     private String secret = "";
 
     public Boolean getVelocity() {


### PR DESCRIPTION
Targets 1.18, java 17. Fixes incompatibility with other mods like [Ledger](https://github.com/QuiltServerTools/Ledger/issues/118)

(Changes taken from FabricProxy-Lite)

Tested on 1.18.1.